### PR TITLE
Fix wrong cast

### DIFF
--- a/src/main/java/ch/qos/logback/core/rolling/S3TimeBasedRollingPolicy.java
+++ b/src/main/java/ch/qos/logback/core/rolling/S3TimeBasedRollingPolicy.java
@@ -98,7 +98,7 @@ public class S3TimeBasedRollingPolicy<E> extends TimeBasedRollingPolicy<E> imple
 
     public Date getLastPeriod() {
 
-        Date lastPeriod = ( (DefaultTimeBasedFileNamingAndTriggeringPolicy<E>) timeBasedFileNamingAndTriggeringPolicy )
+        Date lastPeriod = ( (TimeBasedFileNamingAndTriggeringPolicyBase<E>) timeBasedFileNamingAndTriggeringPolicy )
                 .dateInCurrentPeriod;
 
         if( getParentsRawFileProperty() != null ) {


### PR DESCRIPTION
Old code produced the following exception:
```
od to Wed Jun 01 15:32:23 PDT 2016
15:35:58,030 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@88:21 - RuntimeException in Action for tag [rollingPolicy] java.lang.ClassCastException: ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP cannot be cast to ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy
	at java.lang.ClassCastException: ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP cannot be cast to ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy
	at 	at ch.qos.logback.core.rolling.S3TimeBasedRollingPolicy.getLastPeriod(S3TimeBasedRollingPolicy.java:101)
	at 	at ch.qos.logback.core.rolling.S3TimeBasedRollingPolicy.start(S3TimeBasedRollingPolicy.java:56)
	at 	at ch.qos.logback.core.joran.action.NestedComplexPropertyIA.end(NestedComplexPropertyIA.java:167)
```