### PR TITLE
removed usage header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Index
 -----
 
 * [Requirements](#requirements) 
-* [Usage](#usage) 
 * [Configuration](#configuration) 
   * [logback.xml variables](#logbackxml-variables) 
   * [web.xml](#webxml) 


### PR DESCRIPTION
Removed usage header in readme because the description was not there